### PR TITLE
chore: initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sage"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "auth-git2",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,5 +8,6 @@ pub mod start;
 pub mod status;
 pub mod switch;
 pub mod sync;
+pub mod nuke;
 pub mod clean;
 pub mod history;

--- a/src/app/nuke.rs
+++ b/src/app/nuke.rs
@@ -1,0 +1,59 @@
+use anyhow::{anyhow, Result};
+use crate::{git, errors};
+use crate::tui;
+
+// Removed direct Command use: using git::repo methods
+
+pub async fn nuke() -> Result<()> {
+    // Ensure we're in a git repository
+    if !git::repo::is_repo()? {
+        return Err(errors::GitError::NotARepository.into());
+    }
+
+    // Gather current status
+    let status = git::status::status()?;
+
+    // Show which files will be discarded or removed
+    if status.has_changes() || !status.untracked.is_empty() || !status.ignored.is_empty() {
+        println!("\nThe following changes will be discarded:");
+        for file in status.all_modified_files() {
+            println!("  Modified: {}", file);
+        }
+        for file in status.all_added_files() {
+            println!("  Added: {}", file);
+        }
+        for file in status.all_deleted_files() {
+            println!("  Deleted: {}", file);
+        }
+        for (from, to) in status.all_renamed_files() {
+            println!("  Renamed: {} -> {}", from, to);
+        }
+        for (from, to) in status.all_copied_files() {
+            println!("  Copied: {} -> {}", from, to);
+        }
+        if !status.untracked.is_empty() {
+            println!("\nThe following untracked files/directories will be removed:");
+            for file in &status.untracked {
+                println!("  {}", file);
+            }
+        }
+        if !status.ignored.is_empty() {
+            println!("\nThe following ignored files/directories will be removed:");
+            for file in &status.ignored {
+                println!("  {}", file);
+            }
+        }
+    } else {
+        println!("Working directory is clean, nothing to discard.");
+    }
+
+    // Confirm with user
+    tui::confirm("Are you sure you want to proceed?")?;
+
+    // Proceed with reset and clean
+    git::repo::reset_hard_head()?;
+    git::repo::clean_untracked()?;
+
+    println!("✨ Nuked working directory: Discarded all changes and untracked files.");
+    Ok(())
+}

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -10,6 +10,7 @@ use crate::cli::start;
 use crate::cli::status;
 use crate::cli::switch;
 use crate::cli::sync;
+use crate::cli::nuke;
 
 use clap::Parser;
 
@@ -269,6 +270,13 @@ EXAMPLES:
   sage sync"
     )]
     Sync(sync::SyncArgs),
+
+    /// Nuke the working directory, discarding all changes and untracked files
+    #[clap(
+        long_about = "Forces a hard reset of the working directory and removes untracked files.",
+        alias = "n"
+    )]
+    Nuke(nuke::NukeArgs),
 
     /// Cleans up all dead branches
     Clean(clean::CleanArgs),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub mod list;
 pub mod completion;
 pub mod pr;
 pub mod sync;
+pub mod nuke;
 pub mod clean;
 pub mod history;
 
@@ -39,6 +40,7 @@ impl Run for Cmd {
             Cmd::Completion(cmd) => cmd.run().await,
             Cmd::Pr(cmd) => cmd.run().await,
             Cmd::Sync(cmd) => cmd.run().await,
+            Cmd::Nuke(cmd) => cmd.run().await,
             Cmd::Clean(cmd) => cmd.run().await,
             Cmd::History(cmd) => cmd.run().await,
         }

--- a/src/cli/nuke.rs
+++ b/src/cli/nuke.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::app;
+
+use super::Run;
+
+#[derive(Parser, Debug)]
+pub struct NukeArgs {}
+
+impl Run for NukeArgs {
+    async fn run(&self) -> Result<()> {
+        app::nuke::nuke().await
+    }
+}

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -3,7 +3,6 @@ use git2::Repository;
 use std::path::Path;
 use std::process::Command;
 
-
 /// is_repo returns if user is in an active repo
 pub fn is_repo() -> Result<bool> {
     let result = Command::new("git")
@@ -224,4 +223,37 @@ pub fn fetch_branch(branch_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Reset working directory to HEAD, discarding all changes.
+pub fn reset_hard_head() -> Result<()> {
+    let result = Command::new("git")
+        .arg("reset")
+        .arg("--hard")
+        .arg("HEAD")
+        .output()?;
+    if result.status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Failed to reset changes: {}",
+            String::from_utf8_lossy(&result.stderr)
+        ))
+    }
+}
+
+/// Clean untracked files and directories (including ignored files).
+pub fn clean_untracked() -> Result<()> {
+    let result = Command::new("git")
+        .arg("clean")
+        .arg("-fdx")
+        .output()?;
+    if result.status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Failed to clean untracked files: {}",
+            String::from_utf8_lossy(&result.stderr)
+        ))
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,15 @@
+use anyhow::Result;
+
 pub mod branch;
 pub mod pull;
 
 pub use branch::*;
 
 pub use pull::*; 
+
+
+// confirm
+pub fn confirm(message: &str) -> Result<bool> {
+    let selection = inquire::Confirm::new(message).prompt()?;
+    Ok(selection)
+}


### PR DESCRIPTION
## Summary
This initial commit bootstraps the project by adding a new `nuke` subcommand, setting the AI default model, and fully configuring CI/CD workflows for automated releases, version bumps, and changelog generation.

## Problem
Prior to this work, the repository lacked:
- A reliable way to discard local changes and clean untracked files.
- A consistent default AI model configuration.
- Automated workflows to handle versioning, changelogs, and releases across tags and commit patterns.

Without these elements, developers faced manual overhead, potential misconfiguration, and error‑prone release processes.

## Key Changes
- **New Feature**: Introduce `nuke` subcommand to discard changes and clean untracked files (`feat: add nuke subcommand`)
- **Configuration**: Update default AI model to `o4-mini` (`fix: update ai default model`)
- **Versioning**: Bump versions to 0.3.0, 0.4.0, and 0.4.1 (`chore: bump version … [skip ci]`)
- **Release Workflow Enhancements**:
  - Refactor and simplify versioning and changelog generation
  - Add tag‑based release triggers and standardized commit message formats
  - Improve handling of next‐version detection and release notes
- **CI Updates**:
  - Upgrade `CommitSense` action from v0.1.2 through v0.1.10
  - Fix key naming for OpenAI API in workflows
  - Disable/enable write options for `CommitSense` as needed

## Testing & Review
- Verified `nuke` subcommand on macOS/Linux environments
- Simulated GitHub Actions release pipeline with draft tags and changelog previews
- Manual sanity checks on version bump commits and skip‑CI flags

Areas for extra scrutiny:
- Proper detection of next version in edge cases (e.g., pre‑releases)
- `CommitSense` behavior after upgrades
- Permission scopes for workflow API tokens

## Deployment Considerations
- No breaking changes to existing commands or APIs
- Ensure GitHub Actions secrets (`OPENAI_API_KEY`, `GITHUB_TOKEN`) are set in repo settings
- After merge, new tags (e.g., `v0.4.1`) will auto‑trigger releases with generated notes.